### PR TITLE
Make admin login audit and admin request audit events read-only

### DIFF
--- a/drf_audit_trail/admin.py
+++ b/drf_audit_trail/admin.py
@@ -53,9 +53,6 @@ class RequestAuditEventModelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     def _user(self, obj: RequestAuditEvent):
         return _get_user_by_id(obj.user)
 
-    def has_add_permission(self, request):
-        return False
-
 
 admin.site.register(RequestAuditEvent, RequestAuditEventModelAdmin)
 
@@ -72,9 +69,6 @@ class LoginAuditEventModelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_filter = ("status",)
     search_fields = ("request__ip_addresses", "request__user", "request__url")
     readonly_fields = ["request"]
-
-    def has_add_permission(self, request):
-        return False
 
     @admin.display()
     def request_ip_addresses(self, obj):

--- a/drf_audit_trail/admin.py
+++ b/drf_audit_trail/admin.py
@@ -26,7 +26,18 @@ def _get_user_by_id(user_id: str | None):
         pass
 
 
-class RequestAuditEventModelAdmin(admin.ModelAdmin):
+class ReadonlyAdminMixin(admin.ModelAdmin):
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
+class RequestAuditEventModelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = (
         "id",
         "method",
@@ -49,7 +60,7 @@ class RequestAuditEventModelAdmin(admin.ModelAdmin):
 admin.site.register(RequestAuditEvent, RequestAuditEventModelAdmin)
 
 
-class LoginAuditEventModelAdmin(admin.ModelAdmin):
+class LoginAuditEventModelAdmin(ReadonlyAdminMixin, admin.ModelAdmin):
     list_display = (
         "id",
         "user",


### PR DESCRIPTION
Create an admin mixin and make RequestAuditEvent and LoginAuditEvent models read-only in admin site.